### PR TITLE
feat: ReAct 모드 최대 질의 횟수 워크스페이스별 설정

### DIFF
--- a/frontend/src/locales/en/common.js
+++ b/frontend/src/locales/en/common.js
@@ -307,6 +307,11 @@ const TRANSLATIONS = {
         "desc-start": "will reason step-by-step and",
         search: "iteratively search documents",
         "desc-end": "to provide well-reasoned answers.",
+        maxIterations: {
+          title: "Max Iterations",
+          description:
+            "The maximum number of times the LLM can search documents and reason before providing a final answer. (Min: 1, Max: 25)",
+        },
       },
     },
     history: {

--- a/frontend/src/locales/ko/common.js
+++ b/frontend/src/locales/ko/common.js
@@ -283,6 +283,11 @@ const TRANSLATIONS = {
         "desc-start": "단계별로 추론하며",
         search: "반복적으로 문서를 검색",
         "desc-end": "하여 근거 있는 답변을 제공합니다.",
+        maxIterations: {
+          title: "최대 반복 횟수",
+          description:
+            "최종 답변을 제공하기 전에 LLM이 문서를 검색하고 추론할 수 있는 최대 횟수입니다. (최소: 1, 최대: 25)",
+        },
       },
     },
     history: {

--- a/frontend/src/pages/WorkspaceSettings/ChatSettings/ChatModeSelection/index.jsx
+++ b/frontend/src/pages/WorkspaceSettings/ChatSettings/ChatModeSelection/index.jsx
@@ -2,6 +2,9 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 export default function ChatModeSelection({ workspace, setHasChanges }) {
   const [chatMode, setChatMode] = useState(workspace?.chatMode || "chat");
+  const [reactMaxIterations, setReactMaxIterations] = useState(
+    workspace?.reactMaxIterations ?? 5
+  );
   const { t } = useTranslation();
   return (
     <div>
@@ -72,6 +75,33 @@ export default function ChatModeSelection({ workspace, setHasChanges }) {
             </>
           )}
         </p>
+
+        {chatMode === "react" && (
+          <div className="mt-4">
+            <input
+              type="hidden"
+              name="reactMaxIterations"
+              value={reactMaxIterations}
+            />
+            <label className="block input-label mb-1">
+              {t("chat.mode.react.maxIterations.title")}
+            </label>
+            <p className="text-xs text-white/60 mb-2">
+              {t("chat.mode.react.maxIterations.description")}
+            </p>
+            <input
+              type="number"
+              min={1}
+              max={25}
+              value={reactMaxIterations}
+              onChange={(e) => {
+                setReactMaxIterations(Number(e.target.value));
+                setHasChanges(true);
+              }}
+              className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-[100px] p-2.5"
+            />
+          </div>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/utils/types.js
+++ b/frontend/src/utils/types.js
@@ -12,6 +12,9 @@ export function castToType(key, value) {
     topN: {
       cast: (value) => Number(value),
     },
+    reactMaxIterations: {
+      cast: (value) => Number(value),
+    },
   };
 
   if (!definitions.hasOwnProperty(key)) return value;

--- a/server/models/workspace.js
+++ b/server/models/workspace.js
@@ -56,6 +56,7 @@ const Workspace = {
     "queryRefusalResponse",
     "vectorSearchMode",
     "adjacentChunks",
+    "reactMaxIterations",
   ],
 
   validations: {
@@ -137,6 +138,14 @@ const Workspace = {
       if (chunks < 0) return 0;
       if (chunks > 5) return 5;
       return chunks;
+    },
+    reactMaxIterations: (value) => {
+      if (value === null || value === undefined) return 5;
+      const iterations = parseInt(value);
+      if (isNullOrNaN(iterations)) return 5;
+      if (iterations < 1) return 1;
+      if (iterations > 25) return 25;
+      return iterations;
     },
   },
 

--- a/server/prisma/migrations/20260225000000_add_react_max_iterations/migration.sql
+++ b/server/prisma/migrations/20260225000000_add_react_max_iterations/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "workspaces" ADD COLUMN "reactMaxIterations" INTEGER DEFAULT 5;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -143,6 +143,7 @@ model workspaces {
   queryRefusalResponse         String?
   vectorSearchMode             String?                        @default("default")
   adjacentChunks               Int?                           @default(0)
+  reactMaxIterations           Int?                           @default(5)
   workspace_users              workspace_users[]
   documents                    workspace_documents[]
   workspace_suggested_messages workspace_suggested_messages[]

--- a/server/utils/chats/react/index.js
+++ b/server/utils/chats/react/index.js
@@ -7,7 +7,6 @@ const { writeResponseChunk } = require("../../helpers/chat/responses");
 const { chatPrompt, recentChatHistory, sourceIdentifier } = require("../index");
 const { parseReactOutput } = require("./outputParser");
 
-const MAX_ITERATIONS = 5;
 // Maximum characters per search observation to prevent LLM context window overflow.
 // Tune based on model context limits.
 const OBSERVATION_MAX_CHARS = 2000;
@@ -150,8 +149,9 @@ async function streamReactChat(
     // Keep pinned docs in final citations even if a search returns 0.
     allSources = [...pinnedSources];
 
+    const maxIterations = workspace?.reactMaxIterations ?? 5;
     let llmCallCount = 0;
-    for (let i = 0; i < MAX_ITERATIONS; i++) {
+    for (let i = 0; i < maxIterations; i++) {
       if (response.writableEnded) break;
 
       // Non-streaming LLM call for intermediate steps


### PR DESCRIPTION
## Summary
- ReAct 채팅 모드의 LLM 최대 질의 횟수(기존 하드코딩 5회)를 워크스페이스별로 1~25 범위에서 설정할 수 있도록 추가
- DB 스키마(`reactMaxIterations` 필드), 백엔드 모델 검증, ReAct 핸들러, 프론트엔드 UI, 타입 캐스팅, i18n(en/ko) 일괄 반영

## Test plan
- [x] Prisma 마이그레이션 적용 확인
- [x] 프론트엔드에서 ReAct 모드 선택 시 최대 반복 횟수 입력 필드 노출 확인
- [x] 값 변경 후 저장 → DB 반영 확인 (`reactMaxIterations = 10`)
- [x] 프론트엔드 vitest 전체 통과 (17/17)

🤖 Generated with [Claude Code](https://claude.com/claude-code)