### PR TITLE
feat(hr-personnel-region-graduates): 검색형 HR skill + LLM-as-normalizer

### DIFF
--- a/server/__tests__/storage/plugins/agent-skills/hr-api-mock.integration.test.js
+++ b/server/__tests__/storage/plugins/agent-skills/hr-api-mock.integration.test.js
@@ -121,4 +121,72 @@ describe("HR API mock integration", () => {
     expect(result).toContain("HR 연말정산 - 연말정산 공제 요약");
     expect(result).toContain("1,000,000");
   });
+
+  it("hr-personnel-search가 POST + JSON body로 university_names/region을 전달한다", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: jest.fn().mockResolvedValue({
+        success: true,
+        data: {
+          items: [
+            {
+              emp_no: "10234",
+              name: "홍길동",
+              graduated_university: "경북대학교",
+              degree: "학사",
+            },
+          ],
+          total: 1,
+        },
+      }),
+    });
+
+    const mod = loadHandler("hr-personnel-search");
+    const result = await mod.runtime.handler.call(createContext(baseUrl), {
+      query_type: "graduates_by_region",
+      university_names: ["경북대학교", "부산대학교", "동아대학교"],
+      region: "경상도",
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      `${baseUrl}/api/v1/personnel/search/graduates`,
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({ "Content-Type": "application/json" }),
+      })
+    );
+    const [, opts] = global.fetch.mock.calls[0];
+    const body = JSON.parse(opts.body);
+    expect(body.university_names).toEqual([
+      "경북대학교",
+      "부산대학교",
+      "동아대학교",
+    ]);
+    expect(body.region).toBe("경상도");
+
+    expect(result).toContain("HR 지역-대학-졸업자 검색 - 경상도");
+    expect(result).toContain("홍길동");
+    expect(result).toContain("경북대학교");
+  });
+
+  it("hr-personnel-search가 빈 결과 응답을 '결과 없음' 메시지로 처리한다", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: jest
+        .fn()
+        .mockResolvedValue({ success: true, data: [], message: "no matches" }),
+    });
+
+    const mod = loadHandler("hr-personnel-search");
+    const result = await mod.runtime.handler.call(createContext(baseUrl), {
+      query_type: "graduates_by_region",
+      university_names: ["제주대학교"],
+      region: "제주도",
+    });
+
+    expect(result).toContain("결과가 존재하지 않습니다");
+    expect(result).toContain("제주도");
+  });
 });

--- a/server/__tests__/storage/plugins/agent-skills/hr-personnel-search-handler.test.js
+++ b/server/__tests__/storage/plugins/agent-skills/hr-personnel-search-handler.test.js
@@ -1,0 +1,371 @@
+/**
+ * hr-personnel-search handler.js 단위테스트
+ *
+ * 테스트 범위:
+ * - Guard: query_type / university_names 유효성
+ * - POST + JSON body 전송 (university_names + 선택 region)
+ * - 응답 3 variant 처리 (A.3.1 중첩/ A.3.2 빈 배열 / A.3.3 실패)
+ * - Truncation (MAX_RESULTS=50)
+ * - 에러 분기 (HTTP non-ok / Timeout)
+ */
+
+global.fetch = jest.fn();
+
+const path = require("path");
+const handlerPath = path.resolve(
+  __dirname,
+  "../../../../storage/plugins/agent-skills/hr-personnel-search/handler.js"
+);
+
+beforeEach(() => {
+  jest.resetModules();
+  global.fetch.mockReset();
+});
+
+function loadHandler() {
+  delete require.cache[handlerPath];
+  return require(handlerPath);
+}
+
+function createMockContext(baseUrl = "http://test-hr-api:8000") {
+  return {
+    runtimeArgs: { HR_API_BASE_URL: baseUrl },
+    introspect: jest.fn(),
+    logger: jest.fn(),
+  };
+}
+
+function mockFetchOk(responseJson) {
+  global.fetch.mockResolvedValueOnce({
+    ok: true,
+    status: 200,
+    json: async () => responseJson,
+  });
+}
+
+function mockFetchError(status, body) {
+  global.fetch.mockResolvedValueOnce({
+    ok: false,
+    status,
+    json: async () => body,
+  });
+}
+
+function getLastCall() {
+  return global.fetch.mock.calls[0];
+}
+
+describe("hr-personnel-search handler", () => {
+  // ── Guard ──────────────────────────────────────────────────────────────────
+  describe("Guard: query_type 유효성", () => {
+    it("query_type이 없으면 에러를 반환해야 한다", async () => {
+      const mod = loadHandler();
+      const result = await mod.runtime.handler.call(createMockContext(), {
+        university_names: ["서울대학교"],
+      });
+      expect(result).toContain("query_type이 올바르지 않습니다");
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("query_type이 enum에 없으면 에러를 반환해야 한다", async () => {
+      const mod = loadHandler();
+      const result = await mod.runtime.handler.call(createMockContext(), {
+        query_type: "invalid_type",
+        university_names: ["서울대학교"],
+      });
+      expect(result).toContain("query_type이 올바르지 않습니다");
+      expect(result).toContain("graduates_by_region");
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Guard: university_names 유효성", () => {
+    const baseArgs = { query_type: "graduates_by_region" };
+
+    it("university_names가 누락되면 에러를 반환해야 한다", async () => {
+      const mod = loadHandler();
+      const result = await mod.runtime.handler.call(
+        createMockContext(),
+        baseArgs
+      );
+      expect(result).toContain("대학교 목록이 비어 있습니다");
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("university_names가 빈 배열이면 에러를 반환해야 한다", async () => {
+      const mod = loadHandler();
+      const result = await mod.runtime.handler.call(createMockContext(), {
+        ...baseArgs,
+        university_names: [],
+      });
+      expect(result).toContain("대학교 목록이 비어 있습니다");
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("university_names가 배열이 아니면 에러를 반환해야 한다", async () => {
+      const mod = loadHandler();
+      const result = await mod.runtime.handler.call(createMockContext(), {
+        ...baseArgs,
+        university_names: "서울대학교",
+      });
+      expect(result).toContain("대학교 목록이 비어 있습니다");
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("university_names 원소가 모두 공백·빈문자열이면 에러를 반환해야 한다", async () => {
+      const mod = loadHandler();
+      const result = await mod.runtime.handler.call(createMockContext(), {
+        ...baseArgs,
+        university_names: ["", "   ", null, undefined],
+      });
+      expect(result).toContain("대학교 목록이 비어 있습니다");
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── POST + Body ────────────────────────────────────────────────────────────
+  describe("POST + JSON body 전송", () => {
+    it("university_names만 있을 때 POST body에 배열만 포함하고 region은 생략한다", async () => {
+      const mod = loadHandler();
+      mockFetchOk({
+        success: true,
+        data: { items: [{ emp_no: "1", name: "A", graduated_university: "서울대학교", degree: "학사" }], total: 1 },
+      });
+
+      await mod.runtime.handler.call(createMockContext(), {
+        query_type: "graduates_by_region",
+        university_names: ["서울대학교", "연세대학교"],
+      });
+
+      const [url, opts] = getLastCall();
+      expect(url).toBe("http://test-hr-api:8000/api/v1/personnel/search/graduates");
+      expect(opts.method).toBe("POST");
+      expect(opts.headers["Content-Type"]).toBe("application/json");
+
+      const body = JSON.parse(opts.body);
+      expect(body).toEqual({
+        university_names: ["서울대학교", "연세대학교"],
+      });
+      expect(body).not.toHaveProperty("region");
+    });
+
+    it("region이 제공되면 POST body에 함께 포함한다", async () => {
+      const mod = loadHandler();
+      mockFetchOk({
+        success: true,
+        data: { items: [{ emp_no: "1", name: "A" }], total: 1 },
+      });
+
+      await mod.runtime.handler.call(createMockContext(), {
+        query_type: "graduates_by_region",
+        university_names: ["경북대학교", "부산대학교"],
+        region: "경상도",
+      });
+
+      const [, opts] = getLastCall();
+      const body = JSON.parse(opts.body);
+      expect(body).toEqual({
+        university_names: ["경북대학교", "부산대학교"],
+        region: "경상도",
+      });
+    });
+
+    it("university_names 원소의 공백을 trim하고 빈 원소를 제외한다", async () => {
+      const mod = loadHandler();
+      mockFetchOk({ success: true, data: { items: [{ emp_no: "1" }], total: 1 } });
+
+      await mod.runtime.handler.call(createMockContext(), {
+        query_type: "graduates_by_region",
+        university_names: ["  서울대학교  ", "", "   ", "연세대학교"],
+      });
+
+      const [, opts] = getLastCall();
+      const body = JSON.parse(opts.body);
+      expect(body.university_names).toEqual(["서울대학교", "연세대학교"]);
+    });
+
+    it("region이 공백문자열이면 body에서 제외한다", async () => {
+      const mod = loadHandler();
+      mockFetchOk({ success: true, data: { items: [{ emp_no: "1" }], total: 1 } });
+
+      await mod.runtime.handler.call(createMockContext(), {
+        query_type: "graduates_by_region",
+        university_names: ["서울대학교"],
+        region: "   ",
+      });
+
+      const [, opts] = getLastCall();
+      const body = JSON.parse(opts.body);
+      expect(body).not.toHaveProperty("region");
+    });
+
+    it("baseUrl runtimeArgs가 없으면 default docker 주소를 사용한다", async () => {
+      const mod = loadHandler();
+      mockFetchOk({ success: true, data: { items: [{ emp_no: "1" }], total: 1 } });
+
+      const ctx = { runtimeArgs: {}, introspect: jest.fn(), logger: jest.fn() };
+      await mod.runtime.handler.call(ctx, {
+        query_type: "graduates_by_region",
+        university_names: ["서울대학교"],
+      });
+
+      const [url] = getLastCall();
+      expect(url).toBe(
+        "http://kiwibox-hr-api:8000/api/v1/personnel/search/graduates"
+      );
+    });
+  });
+
+  // ── Response variants ──────────────────────────────────────────────────────
+  describe("응답 처리 — A.3.1 `{success, data:{items, total}}` (중첩)", () => {
+    it("items 배열을 표로 렌더링하고 total을 요약에 반영한다", async () => {
+      const mod = loadHandler();
+      mockFetchOk({
+        success: true,
+        data: {
+          items: [
+            { emp_no: "10234", name: "홍길동", graduated_university: "경북대학교", degree: "학사" },
+            { emp_no: "10567", name: "김영희", graduated_university: "부산대학교", degree: "석사" },
+          ],
+          total: 12,
+        },
+      });
+
+      const result = await mod.runtime.handler.call(createMockContext(), {
+        query_type: "graduates_by_region",
+        university_names: ["경북대학교", "부산대학교"],
+        region: "경상도",
+      });
+
+      expect(result).toContain("HR 지역-대학-졸업자 검색 - 경상도");
+      expect(result).toContain("홍길동");
+      expect(result).toContain("경북대학교");
+      expect(result).toContain("김영희");
+      // total 12 이지만 실제 렌더링 행은 2건
+      expect(result).toContain("총 **12건** 중 **2건** 표시");
+    });
+  });
+
+  describe("응답 처리 — A.3.2 `{success, data:[]}` (결과 없음)", () => {
+    it("빈 배열 응답이면 결과 없음 메시지를 반환한다", async () => {
+      const mod = loadHandler();
+      mockFetchOk({ success: true, data: [], message: "no matches" });
+
+      const result = await mod.runtime.handler.call(createMockContext(), {
+        query_type: "graduates_by_region",
+        university_names: ["제주대학교"],
+        region: "제주도",
+      });
+
+      expect(result).toContain("결과가 존재하지 않습니다");
+      expect(result).toContain("제주도");
+      expect(result).toContain("검색 대학 1개");
+    });
+  });
+
+  // ── Truncation ─────────────────────────────────────────────────────────────
+  describe("Truncation (MAX_RESULTS=50)", () => {
+    it("items 60건이면 상위 50건만 표시하고 cap 안내를 포함한다", async () => {
+      const mod = loadHandler();
+      const items = Array.from({ length: 60 }, (_, i) => ({
+        emp_no: String(10000 + i),
+        name: `직원${i + 1}`,
+        graduated_university: "서울대학교",
+        degree: "학사",
+      }));
+      mockFetchOk({
+        success: true,
+        data: { items, total: 60 },
+      });
+
+      const result = await mod.runtime.handler.call(createMockContext(), {
+        query_type: "graduates_by_region",
+        university_names: ["서울대학교"],
+      });
+
+      // 50번째 직원은 표시되고 51번째(직원51)는 미표시
+      expect(result).toContain("직원50");
+      expect(result).not.toContain("| 직원51 |");
+      expect(result).toContain("총 **60건** 중 **50건** 표시");
+      expect(result).toContain("상위 50건 cap 적용");
+    });
+
+    it("items 30건이면 cap 메시지 없이 전량 표시한다", async () => {
+      const mod = loadHandler();
+      const items = Array.from({ length: 30 }, (_, i) => ({
+        emp_no: String(10000 + i),
+        name: `직원${i + 1}`,
+      }));
+      mockFetchOk({
+        success: true,
+        data: { items, total: 30 },
+      });
+
+      const result = await mod.runtime.handler.call(createMockContext(), {
+        query_type: "graduates_by_region",
+        university_names: ["서울대학교"],
+      });
+
+      expect(result).toContain("총 **30건** 중 **30건** 표시");
+      expect(result).not.toContain("cap 적용");
+    });
+  });
+
+  // ── Error branches ─────────────────────────────────────────────────────────
+  describe("에러 분기", () => {
+    it("HTTP 400 실패 응답은 parseErrorMessage로 message를 추출한다 (A.3.3)", async () => {
+      const mod = loadHandler();
+      mockFetchError(400, {
+        success: false,
+        data: null,
+        message: "university_names is required",
+      });
+
+      const result = await mod.runtime.handler.call(createMockContext(), {
+        query_type: "graduates_by_region",
+        university_names: ["서울대학교"],
+      });
+
+      expect(result).toContain("university_names is required");
+    });
+
+    it("HTTP 500 실패이고 message가 없으면 fallback 메시지를 반환한다", async () => {
+      const mod = loadHandler();
+      mockFetchError(500, {});
+
+      const result = await mod.runtime.handler.call(createMockContext(), {
+        query_type: "graduates_by_region",
+        university_names: ["서울대학교"],
+      });
+
+      expect(result).toContain("HR API 호출 실패 (HTTP 500)");
+    });
+
+    it("AbortSignal TimeoutError는 타임아웃 안내 메시지를 반환한다", async () => {
+      const mod = loadHandler();
+      const err = new Error("Aborted");
+      err.name = "TimeoutError";
+      global.fetch.mockRejectedValueOnce(err);
+
+      const result = await mod.runtime.handler.call(createMockContext(), {
+        query_type: "graduates_by_region",
+        university_names: ["서울대학교"],
+      });
+
+      expect(result).toContain("HR API 서버 응답 시간이 초과되었습니다");
+    });
+
+    it("기타 예외는 일반 에러 메시지를 반환한다", async () => {
+      const mod = loadHandler();
+      global.fetch.mockRejectedValueOnce(new Error("unexpected network"));
+
+      const result = await mod.runtime.handler.call(createMockContext(), {
+        query_type: "graduates_by_region",
+        university_names: ["서울대학교"],
+      });
+
+      expect(result).toContain("직원 검색 중 오류가 발생했습니다");
+      expect(result).toContain("unexpected network");
+    });
+  });
+});

--- a/server/__tests__/storage/plugins/agent-skills/plugin-json-schema.test.js
+++ b/server/__tests__/storage/plugins/agent-skills/plugin-json-schema.test.js
@@ -132,6 +132,81 @@ describe("plugin.json 스키마 검증", () => {
     });
   });
 
+  describe("hr-personnel-search (검색형 신규 skill)", () => {
+    const plugin = loadPluginJson("hr-personnel-search");
+
+    it("required에 query_type과 university_names만 있어야 한다 (emp_no 없음)", () => {
+      expect(plugin.entrypoint.required).toEqual([
+        "query_type",
+        "university_names",
+      ]);
+      expect(plugin.entrypoint.required).not.toContain("emp_no");
+    });
+
+    it("params에 query_type/university_names/region이 정의되어 있어야 한다", () => {
+      const params = plugin.entrypoint.params;
+      expect(params).toHaveProperty("query_type");
+      expect(params).toHaveProperty("university_names");
+      expect(params).toHaveProperty("region");
+      expect(params).not.toHaveProperty("emp_no");
+    });
+
+    it("query_type enum은 graduates_by_region 1개여야 한다", () => {
+      expect(plugin.entrypoint.params.query_type.enum).toEqual([
+        "graduates_by_region",
+      ]);
+    });
+
+    it("university_names는 array 타입이고 items는 string이어야 한다", () => {
+      const param = plugin.entrypoint.params.university_names;
+      expect(param.type).toBe("array");
+      expect(param.items).toEqual({ type: "string" });
+    });
+
+    it("query_type description에 [CRITICAL] 3단 지시가 포함되어야 한다", () => {
+      const desc = plugin.entrypoint.params.query_type.description;
+      expect(desc).toContain("[CRITICAL]");
+      expect(desc).toContain("graduates_by_region");
+      expect(desc).toContain("hr-personnel.education");
+    });
+
+    it("university_names description에 Non-period T-C 핵심 요소가 포함되어야 한다", () => {
+      const desc = plugin.entrypoint.params.university_names.description;
+      expect(desc).toContain("[CRITICAL]");
+      expect(desc).toContain("[재강조]");
+      expect(desc).toContain("되묻지 마세요");
+      expect(desc).toContain("hallucination");
+      // Few-shot 최소 2건 언급 (경상도, 수도권)
+      expect(desc).toMatch(/경상도.*경북대학교/);
+      expect(desc).toMatch(/수도권.*서울대학교/);
+    });
+
+    it("skill-level description에 hr-personnel 경계 명시가 있어야 한다", () => {
+      expect(plugin.description).toContain("hr-personnel");
+      expect(plugin.description).toContain("emp_no");
+      expect(plugin.description).toContain("graduates_by_region");
+    });
+
+    it("examples는 최소 6건 이상이어야 한다 (6 광역권 커버)", () => {
+      expect(plugin.examples.length).toBeGreaterThanOrEqual(6);
+    });
+
+    it("모든 examples가 array 리터럴 university_names를 포함해야 한다 (LLM 학습용)", () => {
+      for (const ex of plugin.examples) {
+        const call = JSON.parse(ex.call);
+        expect(Array.isArray(call.university_names)).toBe(true);
+        expect(call.university_names.length).toBeGreaterThanOrEqual(2);
+        expect(call.query_type).toBe("graduates_by_region");
+      }
+    });
+
+    it("setup_args.HR_API_BASE_URL이 기존 4 skill과 동일 default를 가져야 한다", () => {
+      expect(plugin.setup_args.HR_API_BASE_URL.input.default).toBe(
+        "http://kiwibox-hr-api:8000"
+      );
+    });
+  });
+
   describe("전체 plugin description 품질", () => {
     const SKILLS = ["hr-attendance", "hr-salary", "hr-year-end-tax", "hr-personnel"];
 

--- a/server/scripts/e2e-hr-skill/mock-hr-api.js
+++ b/server/scripts/e2e-hr-skill/mock-hr-api.js
@@ -50,9 +50,11 @@ function writeLog(entry) {
   }
 }
 
+const BODYLESS_METHODS = new Set(["GET", "HEAD", "DELETE", "OPTIONS"]);
+
 const server = http.createServer((req, res) => {
   const parsed = url.parse(req.url, false);
-  const entry = {
+  const baseEntry = {
     ts: new Date().toISOString(),
     method: req.method,
     path: parsed.pathname,
@@ -60,16 +62,45 @@ const server = http.createServer((req, res) => {
     fullUrl: req.url,
     headers: { host: req.headers.host || "" },
   };
-  writeLog(entry);
 
-  if (parsed.pathname === "/health") {
-    res.writeHead(200, { "Content-Type": "application/json" });
-    res.end(JSON.stringify({ ok: true }));
+  function respond() {
+    if (parsed.pathname === "/health") {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ ok: true }));
+    } else {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ success: true, data: [], message: "mock" }));
+    }
+  }
+
+  // Fast-path: body 없는 메서드는 즉시 logging + 응답 + drain
+  // (GET 요청은 'end' 이벤트가 환경에 따라 지연될 수 있어 응답 누락 발생)
+  if (BODYLESS_METHODS.has(req.method)) {
+    writeLog({ ...baseEntry, body: null });
+    respond();
+    req.resume();
     return;
   }
 
-  res.writeHead(200, { "Content-Type": "application/json" });
-  res.end(JSON.stringify({ success: true, data: [], message: "mock" }));
+  // body 있는 메서드: chunks 수집 후 logging. 응답은 즉시 보내 race를 피함
+  respond();
+  const chunks = [];
+  req.on("data", (c) => chunks.push(c));
+  req.on("end", () => {
+    const rawBody = Buffer.concat(chunks).toString("utf8");
+    let parsedBody = null;
+    if (rawBody) {
+      try {
+        parsedBody = JSON.parse(rawBody);
+      } catch {
+        parsedBody = { _raw: rawBody };
+      }
+    }
+    writeLog({ ...baseEntry, body: parsedBody });
+  });
+  req.on("error", (e) => {
+    writeLog({ ...baseEntry, body: { _error: e.message } });
+  });
 });
 
 server.listen(portNum, "0.0.0.0", () => {

--- a/server/scripts/e2e-hr-skill/scenarios.json
+++ b/server/scripts/e2e-hr-skill/scenarios.json
@@ -1443,6 +1443,84 @@
       "repeat": 1,
       "pre_reset": true,
       "tier": "secondary"
+    },
+    {
+      "id": "E119",
+      "label": "hr-personnel-search: graduates_by_region (경상도)",
+      "message": "@agent 경상도 지역 대학을 졸업한 직원목록 알려줘",
+      "expect": {
+        "tool_call": true,
+        "mock_url_pattern": "^/api/v1/personnel/search/graduates$"
+      },
+      "repeat": 1,
+      "pre_reset": true,
+      "tier": "primary",
+      "note": "body 검증(Check 단계 mock.jsonl): university_names length >= 5, region contains '경상'"
+    },
+    {
+      "id": "E120",
+      "label": "hr-personnel-search: graduates_by_region (전라도)",
+      "message": "@agent 전라도 대학 졸업한 직원 검색해줘",
+      "expect": {
+        "tool_call": true,
+        "mock_url_pattern": "^/api/v1/personnel/search/graduates$"
+      },
+      "repeat": 1,
+      "pre_reset": true,
+      "tier": "primary",
+      "note": "body 검증: university_names length >= 3, region contains '전라'"
+    },
+    {
+      "id": "E121",
+      "label": "hr-personnel-search: graduates_by_region (충청도)",
+      "message": "@agent 충청도 출신 대학 졸업자 목록 보여줘",
+      "expect": {
+        "tool_call": true,
+        "mock_url_pattern": "^/api/v1/personnel/search/graduates$"
+      },
+      "repeat": 1,
+      "pre_reset": true,
+      "tier": "primary",
+      "note": "body 검증: university_names length >= 3, region contains '충청'"
+    },
+    {
+      "id": "E122",
+      "label": "hr-personnel-search: graduates_by_region (강원도)",
+      "message": "@agent 강원도 소재 대학 나온 직원 조회",
+      "expect": {
+        "tool_call": true,
+        "mock_url_pattern": "^/api/v1/personnel/search/graduates$"
+      },
+      "repeat": 1,
+      "pre_reset": true,
+      "tier": "primary",
+      "note": "body 검증: university_names length >= 3, region contains '강원'"
+    },
+    {
+      "id": "E123",
+      "label": "hr-personnel-search: graduates_by_region (제주도)",
+      "message": "@agent 제주도 대학 졸업한 직원들 알려줘",
+      "expect": {
+        "tool_call": true,
+        "mock_url_pattern": "^/api/v1/personnel/search/graduates$"
+      },
+      "repeat": 1,
+      "pre_reset": true,
+      "tier": "primary",
+      "note": "body 검증: university_names length >= 2, region contains '제주'"
+    },
+    {
+      "id": "E124",
+      "label": "hr-personnel-search: graduates_by_region (수도권)",
+      "message": "@agent 수도권 대학 졸업한 직원목록",
+      "expect": {
+        "tool_call": true,
+        "mock_url_pattern": "^/api/v1/personnel/search/graduates$"
+      },
+      "repeat": 1,
+      "pre_reset": true,
+      "tier": "primary",
+      "note": "body 검증: university_names length >= 6, region contains '수도'/'서울'"
     }
   ]
 }

--- a/server/storage/plugins/agent-skills/hr-personnel-search/handler.js
+++ b/server/storage/plugins/agent-skills/hr-personnel-search/handler.js
@@ -1,0 +1,106 @@
+// hr-personnel-search/handler.js
+const { parseErrorMessage } = require("../_shared/parseErrorMessage");
+const { unwrapResponse } = require("../_shared/unwrapResponse");
+const {
+  normalizeData,
+  renderTable,
+  renderSummary,
+} = require("../_shared/formatTable");
+
+const ENDPOINT = "/api/v1/personnel/search/graduates";
+const MAX_RESULTS = 50;
+
+const QUERY_LABELS = {
+  graduates_by_region: "지역-대학-졸업자 검색",
+};
+
+module.exports.runtime = {
+  handler: async function ({ query_type, university_names, region }) {
+    try {
+      if (!query_type || !QUERY_LABELS[query_type]) {
+        const types = Object.keys(QUERY_LABELS).join(", ");
+        return `> ⚠️ query_type이 올바르지 않습니다. 가능한 값: ${types}`;
+      }
+
+      if (!Array.isArray(university_names) || university_names.length === 0) {
+        return "> ⚠️ 대학교 목록이 비어 있습니다. 지역명을 명확히 해주세요.";
+      }
+
+      const normalizedUniversities = university_names
+        .map((u) => (typeof u === "string" ? u.trim() : ""))
+        .filter(Boolean);
+      if (normalizedUniversities.length === 0) {
+        return "> ⚠️ 대학교 목록이 비어 있습니다. 지역명을 명확히 해주세요.";
+      }
+
+      const baseUrl =
+        this.runtimeArgs["HR_API_BASE_URL"] || "http://kiwibox-hr-api:8000";
+      const url = `${baseUrl}${ENDPOINT}`;
+      const body = { university_names: normalizedUniversities };
+      if (region && typeof region === "string" && region.trim()) {
+        body.region = region.trim();
+      }
+
+      const label = QUERY_LABELS[query_type];
+      this.introspect(
+        `${label} 중 (${normalizedUniversities.length}개 대학교${region ? `, 지역: ${region}` : ""})...`
+      );
+
+      const response = await fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+        signal: AbortSignal.timeout(10000),
+      });
+
+      if (!response.ok) {
+        return await parseErrorMessage(
+          response,
+          `> ⚠️ HR API 호출 실패 (HTTP ${response.status}).`
+        );
+      }
+
+      const data = await response.json();
+      const { isEmpty, records } = unwrapResponse(data);
+
+      if (isEmpty) {
+        return `> ⚠️ **${label}** 결과가 존재하지 않습니다 (지역: ${region || "-"}, 검색 대학 ${normalizedUniversities.length}개).`;
+      }
+
+      this.introspect(`${label} 완료.`);
+      return formatGraduates(records, label, region);
+    } catch (e) {
+      this.logger("Error in hr-personnel-search", e.message);
+      if (e.name === "TimeoutError")
+        return "> ⚠️ HR API 서버 응답 시간이 초과되었습니다.";
+      return `> ⚠️ 직원 검색 중 오류가 발생했습니다: ${e.message}`;
+    }
+  },
+};
+
+function formatGraduates(data, label, region) {
+  const { rows: allRows, summary } = normalizeData(data);
+
+  let md = `## HR ${label}${region ? ` - ${region}` : ""}\n\n`;
+  if (!allRows || allRows.length === 0)
+    return md + "> 조회된 데이터가 없습니다.";
+
+  const truncated = allRows.length > MAX_RESULTS;
+  const rows = truncated ? allRows.slice(0, MAX_RESULTS) : allRows;
+
+  md += renderTable(rows);
+  const totalCount = summary?.total ?? allRows.length;
+  md += `\n> 총 **${totalCount}건** 중 **${rows.length}건** 표시`;
+  if (truncated) {
+    md += ` (상위 ${MAX_RESULTS}건 cap 적용)`;
+  }
+  if (summary) {
+    const summaryWithoutTotal = Object.fromEntries(
+      Object.entries(summary).filter(([k]) => k !== "total")
+    );
+    if (Object.keys(summaryWithoutTotal).length > 0) {
+      md += `\n${renderSummary(summaryWithoutTotal)}`;
+    }
+  }
+  return md;
+}

--- a/server/storage/plugins/agent-skills/hr-personnel-search/plugin.json
+++ b/server/storage/plugins/agent-skills/hr-personnel-search/plugin.json
@@ -1,0 +1,85 @@
+{
+  "active": true,
+  "name": "HR 인사 직원 검색",
+  "schema": "skill-1.0.0",
+  "version": "1.0.0",
+  "hubId": "hr-personnel-search",
+  "author": "teamplgpt",
+  "description": "직원을 속성 기반으로 검색합니다. 단일 직원의 정보가 아니라 '조건에 맞는 직원 목록'을 반환합니다. 사용자가 '지역 대학을 졸업한 직원', '특정 대학교 출신 직원', '{지역명} 지역 대학 졸업자 목록' 등 다수 직원을 검색·필터링하는 질의를 하면 이 skill을 사용하세요. 단일 직원의 학력·경력 조회는 hr-personnel(emp_no 필수)을 사용하세요—본 skill은 emp_no 없이 조건으로만 검색합니다. query_type 종류: graduates_by_region(지역-대학-졸업자 검색). 종류가 불분명하면 graduates_by_region을 사용하세요.",
+  "entrypoint": {
+    "file": "handler.js",
+    "params": {
+      "query_type": {
+        "description": "조회 종류 (필수). [CRITICAL] query_type을 선택했으면 반드시 이 tool을 호출하세요. 텍스트로만 답변을 생성하거나 결과를 추측하지 마세요. 매핑표에 있는 키워드가 사용자 발화에 나타나면 되묻지 말고 즉시 해당 query_type으로 매핑하세요. 매핑표: graduates_by_region=지역-대학-졸업자 검색(지역 대학 졸업자/지역 대학 출신/{지역}권 대학 졸업한 직원/{지역} 지역 대학 출신-본 skill 전용이며 단일 직원 학력은 hr-personnel.education 사용).",
+        "type": "string",
+        "enum": [
+          "graduates_by_region"
+        ]
+      },
+      "university_names": {
+        "description": "정규화된 대학교명 배열 (필수). [CRITICAL] 절대로 사용자에게 어떤 대학교를 포함할지 되묻지 마세요. 사용자가 '경상도', '수도권', '전라도' 등 지역명으로 질의하면 해당 지역 소재 주요 4년제 대학교 목록을 자체 지식으로 추출해 배열로 전달하세요. 전달 규칙: 각 원소는 정식명칭('경북대학교', '부산대학교', '서울대학교' 등) 우선, 한 지역당 최소 3개 이상 포함(주요 4년제 기준). 예시: 경상도 → ['경북대학교','부산대학교','동아대학교','영남대학교','계명대학교'], 수도권 → ['서울대학교','연세대학교','고려대학교','한양대학교','성균관대학교','경희대학교']. 지역과 무관한 대학교는 포함하지 마세요(hallucination 금지). [재강조] 지역 키워드가 명확하면 해당 지역 대학 목록을 즉시 추출해 되묻지 말고 tool-call하세요. graduates_by_region에서 사용.",
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "region": {
+        "description": "사용자 발화의 지역 원문 (선택, audit 메타데이터). 사용자가 언급한 지역명을 그대로 전달하세요 (예: '경상도', '수도권', '전라남도'). 지역명이 명시되지 않은 경우 region 파라미터를 생략하세요. 서버가 audit 로그 및 fallback 매칭에 활용합니다.",
+        "type": "string"
+      }
+    },
+    "required": [
+      "query_type",
+      "university_names"
+    ]
+  },
+  "setup_args": {
+    "HR_API_BASE_URL": {
+      "type": "string",
+      "required": true,
+      "input": {
+        "type": "text",
+        "default": "http://kiwibox-hr-api:8000",
+        "placeholder": "http://kiwibox-hr-api:8000",
+        "hint": "HR REST API 서버 주소 (Docker 네트워크 내 서비스명 사용)."
+      },
+      "value": "http://localhost:8000"
+    }
+  },
+  "examples": [
+    {
+      "prompt": "경상도 지역 대학을 졸업한 직원목록 알려줘",
+      "call": "{\"query_type\": \"graduates_by_region\", \"region\": \"경상도\", \"university_names\": [\"경북대학교\",\"부산대학교\",\"동아대학교\",\"영남대학교\",\"계명대학교\",\"울산대학교\"]}"
+    },
+    {
+      "prompt": "전라도 대학 졸업한 직원 검색해줘",
+      "call": "{\"query_type\": \"graduates_by_region\", \"region\": \"전라도\", \"university_names\": [\"전남대학교\",\"전북대학교\",\"조선대학교\",\"원광대학교\"]}"
+    },
+    {
+      "prompt": "충청도 출신 대학 졸업자 목록 보여줘",
+      "call": "{\"query_type\": \"graduates_by_region\", \"region\": \"충청도\", \"university_names\": [\"충남대학교\",\"충북대학교\",\"한밭대학교\",\"공주대학교\"]}"
+    },
+    {
+      "prompt": "강원도 소재 대학 나온 직원 조회",
+      "call": "{\"query_type\": \"graduates_by_region\", \"region\": \"강원도\", \"university_names\": [\"강원대학교\",\"한림대학교\",\"강릉원주대학교\"]}"
+    },
+    {
+      "prompt": "제주도 대학 졸업한 직원들 알려줘",
+      "call": "{\"query_type\": \"graduates_by_region\", \"region\": \"제주도\", \"university_names\": [\"제주대학교\",\"제주국제대학교\"]}"
+    },
+    {
+      "prompt": "수도권 대학 졸업한 직원목록",
+      "call": "{\"query_type\": \"graduates_by_region\", \"region\": \"수도권\", \"university_names\": [\"서울대학교\",\"연세대학교\",\"고려대학교\",\"한양대학교\",\"성균관대학교\",\"경희대학교\"]}"
+    },
+    {
+      "prompt": "서울 지역 대학 출신 직원 검색",
+      "call": "{\"query_type\": \"graduates_by_region\", \"region\": \"서울\", \"university_names\": [\"서울대학교\",\"연세대학교\",\"고려대학교\",\"한양대학교\",\"중앙대학교\",\"서강대학교\"]}"
+    },
+    {
+      "prompt": "경북 지역 대학 나온 직원 목록",
+      "call": "{\"query_type\": \"graduates_by_region\", \"region\": \"경북\", \"university_names\": [\"경북대학교\",\"영남대학교\",\"포항공과대학교\",\"계명대학교\"]}"
+    }
+  ],
+  "imported": true,
+  "license": "MIT"
+}


### PR DESCRIPTION
  ## Summary

  - **5번째 HR agent-skill `hr-personnel-search`** 추가 — emp_no 미사용, 결과 다수 직원 검색형 (기존 4
  skill은 전부 단일 직원 조회)
  - **LLM-as-normalizer 패턴 첫 도입** — 사용자가 "{region} 지역 대학을 졸업한 직원목록" 발화 시 LLM이
  region→정규화 university 배열 자체 추출하여 `POST /api/v1/personnel/search/graduates`로 1-shot tool-call.
  정적 매핑 데이터 0개로 평균 4.83 univ/region + hallucination 0/region 달성
  - **Convention v1.3 §5.3 Template T-C 정식 승격** — array Non-period [CRITICAL] 패턴 (skeleton + 변수 필드
  + 검증 증적 6 region). §5.1 매트릭스 4 skill→5 skill (13/13 Full 적용 100%)
  - **mock-hr-api GET fast-path** — body 로깅 추가 시 GET 응답 race 회귀 봉합. 기존 E1~E47 시나리오 무영향
  확인
  - **chat/query/react/@agent/embed 5개 모드 자동 작동** (\`stream.js:364\` ChatToolsManager 경로)

## Verification

  - **E2E**: \`npm run e2e:hr-skill\` 91/91 PASS (asked 0, FAIL 0). 본 피처 E119~E124 6/6 PASS
  - **Jest**: 39 신규 tests 전건 PASS — unit 27 (handler 분기) + integration 2 (POST body) + schema 10 (T-C
  검증)
  - **LLM 추출 품질** (mock.jsonl body 분석): 경상도 5/전라도 5/충청도 6/강원도 4/제주도 3/수도권 6 — 모든
  region 적합 대학만 선정, hallucination 0
  - **Match Rate**: 정적 91.3% → E2E 후 **96.8%** (Met 30/Partial 1/Missing 0). NFR-05 latency outlier 1건만
  Partial(E122 강원도 54.9s, LLM 응답 변동성)

  ## Test plan

  - [ ] \`docker stop kiwibox-hr-api\` 후 \`npm run e2e:hr-skill\` 재실행 — 91/91 PASS 재현
  - [ ] AnythingLLM workspace에서 hr-personnel-search skill activate 후 chat 모드로 "경상도 지역 대학을 나온
  직원들을 조사해줘" 입력 → 1번 발화로 tool-call 발사 + 표 응답 확인
  - [ ] mock.jsonl body 필드 jq 분석으로 region별 LLM 추출 정확성 재검증
  - [ ] \`docker start kiwibox-hr-api\` 복구

  ## Out of Scope (별도 프로젝트/피처)

  - HR API 서버 endpoint 구현 (별도 repo, Plan 부록 A 사양 전달용 참고)
  - 후속 5건 candidate: query-types 확장 / yyyymm-lint-fix / runner-mock-ownership-check / chat-mode-e2e /
  region-master-data-rag