### PR TITLE
feat(hr-skill-tool-schema-array-items): ChatToolsManager items pass-through + HR_API_BASE_URL hotfix

### DIFF
--- a/server/__tests__/utils/chats/toolCalling/manager.test.js
+++ b/server/__tests__/utils/chats/toolCalling/manager.test.js
@@ -41,6 +41,43 @@ const MOCK_INACTIVE_PLUGIN = {
   entrypoint: { params: {}, required: [] },
 };
 
+const MOCK_ARRAY_PLUGIN = {
+  active: true,
+  hubId: "hr-personnel-search",
+  description: "직원을 속성 기반으로 검색합니다.",
+  entrypoint: {
+    params: {
+      query_type: {
+        type: "string",
+        description: "조회 종류",
+        enum: ["graduates_by_region"],
+      },
+      university_names: {
+        type: "array",
+        description: "정규화된 대학교명 배열",
+        items: { type: "string" },
+      },
+      region: {
+        type: "string",
+        description: "지역 원문",
+      },
+    },
+    required: ["query_type", "university_names"],
+  },
+};
+
+const MOCK_ARRAY_MISSING_ITEMS_PLUGIN = {
+  active: true,
+  hubId: "broken-array",
+  description: "Items 누락 플러그인(회귀 방어).",
+  entrypoint: {
+    params: {
+      tags: { type: "array", description: "태그 배열" },
+    },
+    required: ["tags"],
+  },
+};
+
 beforeEach(() => {
   jest.clearAllMocks();
 });
@@ -185,6 +222,55 @@ describe("ChatToolsManager", () => {
           },
         },
       });
+    });
+  });
+
+  describe("array type with items (FR-05, FR-06)", () => {
+    it("openai-responses: array items를 보존해야 한다", () => {
+      ImportedPlugin.listImportedPlugins.mockReturnValue([MOCK_ARRAY_PLUGIN]);
+      const [tool] = ChatToolsManager.getToolDefinitions("openai-responses");
+      expect(tool.parameters.properties.university_names).toEqual({
+        type: "array",
+        description: "정규화된 대학교명 배열",
+        items: { type: "string" },
+      });
+    });
+
+    it("anthropic: array items를 보존해야 한다", () => {
+      ImportedPlugin.listImportedPlugins.mockReturnValue([MOCK_ARRAY_PLUGIN]);
+      const [tool] = ChatToolsManager.getToolDefinitions("anthropic");
+      expect(tool.input_schema.properties.university_names.items).toEqual({
+        type: "string",
+      });
+    });
+
+    it("chat-completions: array items를 보존해야 한다", () => {
+      ImportedPlugin.listImportedPlugins.mockReturnValue([MOCK_ARRAY_PLUGIN]);
+      const [tool] = ChatToolsManager.getToolDefinitions("chat-completions");
+      expect(
+        tool.function.parameters.properties.university_names.items
+      ).toEqual({ type: "string" });
+    });
+
+    it("items 미선언 array는 defensive default { type: string }을 주입해야 한다", () => {
+      const warnSpy = jest
+        .spyOn(console, "warn")
+        .mockImplementation(() => {});
+      ImportedPlugin.listImportedPlugins.mockReturnValue([
+        MOCK_ARRAY_MISSING_ITEMS_PLUGIN,
+      ]);
+      const [tool] = ChatToolsManager.getToolDefinitions("openai-responses");
+      expect(tool.parameters.properties.tags).toEqual({
+        type: "array",
+        description: "태그 배열",
+        items: { type: "string" },
+      });
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'param "tags" is array type but missing "items"'
+        )
+      );
+      warnSpy.mockRestore();
     });
   });
 

--- a/server/scripts/e2e-hr-skill/scenarios.json
+++ b/server/scripts/e2e-hr-skill/scenarios.json
@@ -1521,6 +1521,19 @@
       "pre_reset": true,
       "tier": "primary",
       "note": "body 검증: university_names length >= 6, region contains '수도'/'서울'"
+    },
+    {
+      "id": "E125",
+      "label": "hr-personnel-search: chat/query 경로 array items 스키마 검증 (경상도)",
+      "message": "경상도 지역 대학을 졸업한 직원목록 알려줘",
+      "expect": {
+        "tool_call": true,
+        "mock_url_pattern": "^/api/v1/personnel/search/graduates$"
+      },
+      "repeat": 1,
+      "pre_reset": true,
+      "tier": "primary",
+      "note": "@agent 접두사 없음 → ChatToolsManager 경유 (chat/query 모드). fix 전: OpenAI 400 invalid_function_parameters (array schema missing items). fix 후: tool_call 성공 + university_names 배열 body 포함."
     }
   ]
 }

--- a/server/storage/plugins/agent-skills/hr-attendance/plugin.json
+++ b/server/storage/plugins/agent-skills/hr-attendance/plugin.json
@@ -69,7 +69,7 @@
         "placeholder": "http://kiwibox-hr-api:8000",
         "hint": "HR REST API 서버 주소 (Docker 네트워크 내 서비스명 사용)."
       },
-      "value": "http://localhost:8000"
+      "value": "http://kiwibox-hr-api:8000"
     }
   },
   "examples": [

--- a/server/storage/plugins/agent-skills/hr-personnel-search/plugin.json
+++ b/server/storage/plugins/agent-skills/hr-personnel-search/plugin.json
@@ -43,7 +43,7 @@
         "placeholder": "http://kiwibox-hr-api:8000",
         "hint": "HR REST API 서버 주소 (Docker 네트워크 내 서비스명 사용)."
       },
-      "value": "http://localhost:8000"
+      "value": "http://kiwibox-hr-api:8000"
     }
   },
   "examples": [

--- a/server/storage/plugins/agent-skills/hr-personnel/plugin.json
+++ b/server/storage/plugins/agent-skills/hr-personnel/plugin.json
@@ -46,7 +46,7 @@
         "placeholder": "http://kiwibox-hr-api:8000",
         "hint": "HR REST API 서버 주소 (Docker 네트워크 내 서비스명 사용)."
       },
-      "value": "http://localhost:8000"
+      "value": "http://kiwibox-hr-api:8000"
     }
   },
   "examples": [

--- a/server/storage/plugins/agent-skills/hr-salary/plugin.json
+++ b/server/storage/plugins/agent-skills/hr-salary/plugin.json
@@ -65,7 +65,7 @@
         "placeholder": "http://kiwibox-hr-api:8000",
         "hint": "HR REST API 서버 주소 (Docker 네트워크 내 서비스명 사용)."
       },
-      "value": "http://localhost:8000"
+      "value": "http://kiwibox-hr-api:8000"
     }
   },
   "examples": [

--- a/server/storage/plugins/agent-skills/hr-year-end-tax/plugin.json
+++ b/server/storage/plugins/agent-skills/hr-year-end-tax/plugin.json
@@ -49,7 +49,7 @@
         "placeholder": "http://kiwibox-hr-api:8000",
         "hint": "HR REST API 서버 주소 (Docker 네트워크 내 서비스명 사용)."
       },
-      "value": "http://localhost:8000"
+      "value": "http://kiwibox-hr-api:8000"
     }
   },
   "examples": [

--- a/server/utils/chats/toolCalling/manager.js
+++ b/server/utils/chats/toolCalling/manager.js
@@ -57,6 +57,28 @@ class ChatToolsManager {
       const prop = { type: def.type || "string" };
       if (def.description) prop.description = def.description;
       if (def.enum) prop.enum = def.enum;
+
+      if (prop.type === "array") {
+        if (def.items) {
+          prop.items = def.items;
+        } else {
+          console.warn(
+            `[ChatToolsManager] Plugin "${pluginConfig.hubId}" param "${key}" ` +
+              `is array type but missing "items". Falling back to { type: "string" }.`
+          );
+          prop.items = { type: "string" };
+        }
+      }
+
+      if (prop.type === "object" && def.properties) {
+        prop.properties = def.properties;
+        if (def.required) prop.required = def.required;
+      }
+
+      if (def.default !== undefined) prop.default = def.default;
+      if (typeof def.minItems === "number") prop.minItems = def.minItems;
+      if (typeof def.maxItems === "number") prop.maxItems = def.maxItems;
+
       properties[key] = prop;
     }
     return {


### PR DESCRIPTION
## Summary

  ### 1. ChatToolsManager JSON Schema items pass-through 복구 (primary)
  - \`#buildSchema\`가 plugin.json \`entrypoint.params\`의 \`items\`를 드롭하여 OpenAI Responses API가 \`invalid_function_parameters: array schema missing
  items\` 400을 반환하던 회귀 수정
  - \`hr-personnel-search.university_names\`가 최초 array 파라미터로 도입되며 운영 노출 — 기존 4 HR skill은 scalar만 사용해 가려져 있던 core infra 결함
  - 3 provider (OpenAI Responses / Anthropic / Chat Completions) 공통 헬퍼 1곳 수정으로 chat/query + embed 경로 동시 복구
  - defensive default(\`{type:'string'}\` + \`console.warn\`) + properties/default/minItems/maxItems pass-through 확장

  ### 2. HR_API_BASE_URL hotfix (ancillary)
  - 5개 HR plugin의 \`setup_args.HR_API_BASE_URL.value\`를 \`localhost:8000\` → \`kiwibox-hr-api:8000\`로 교체
  - anythingllm 컨테이너에서 localhost는 자기 자신을 가리켜 7ms 즉시 fetch failed 발생하던 운영 장애 해결

  ## 3-Mode 영향
  | Mode | 상태 |
  |------|------|
  | chat/query | BUG FIXED (ChatToolsManager 경유) |
  | embed | BUG FIXED (공유 경로) |
  | @agent | SAFE (imported.js:195 raw params) |
  | react | N/A (ReAct 텍스트 프롬프트, ChatToolsManager 미사용) |

  ## Test plan
  - [x] \`npm test -- manager.test.js\` 13/13 PASS (기존 9 + 신규 4)
  - [ ] \`npm run e2e:hr-skill\` regression (사용자 수동 실행)
  - [ ] Manual verify: \"경상도 지역 대학교 졸업자들을 알려줘\" 발화 — OpenAI 400 없음 + hr-personnel-search tool-call 성공